### PR TITLE
Update README.md step 6 initial state value for 'found' prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,7 +973,7 @@ In this step, we'll start creating our store's reducer and the action creators t
     propertyType: 'Single Family Home',
     city: '',
     propToBeUsedOn: '',
-    found: false,
+    found: "false",
     realEstateAgent: "false",
     cost: 0,
     downPayment: 0,


### PR DESCRIPTION
Initial state has the 'found' property initialized to boolean false, it should be wrapped in quotes for string value. Otherwise, it will not show up on WizardEleven.