### PR TITLE
Do not hook up App.js to redux store

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,58 +444,14 @@ export default App;
 
 ### Summary
 
-In this step, we'll be looking at `src/App.js` to modify it to handle state with the `redux` store.
-
-Open `src/App.js`. You'll notice that throughout this file there are comments, these comments are there to more easily show which pieces of state have to do with which views/routes. In this step, we're just going to connect `src/App.js` and the first view to redux. 
-
-Sidenote: You can either leave the constructor function, super, state, all of the bound functions and regular functions that originally dealt with state in there if you'd like. Or it may help to take out the specific ones that deal with state one at a time as you connect things to redux. I'll be removing them all at once. 
+In this step, we'll be removing the state and handler methods from `App.js`. That's because we no longer need either. Instead, all of our wizard steps (components) will connect to the redux store separately, and we don't need to track state in `App.js`, just for the sake of passing it down as props.
 
 ### Instructions
 
 * Open `src/App.js`.
-* Import `connect` from `react-redux`
-* Make a function called `mapStateToProps` just above the `export default` statement.
-  * This function should have a parameter called `state`.
-  * This function should return the `state` parameter.
-* Modify the `export default` statement to use `connect` instead.
-  * Be sure to pass in the `mapStateToProps` function.
-
-<details>
-
-<summary> Detailed Instructions </summary>
-
-<br />
-
-Let's begin by opening `src/App.js`. In this file we are going to modify to component to connect to our `redux` store. To do this, we'll need to import `connect` from `react-redux`.
-
-```js
-import { connect } from 'react-redux'
-```
-
-Before we connect our app to `redux`, we'll need to make a function called `mapStateToProps`. This allows us to choose what parts of state we want from the `redux` store. For now, we'll just return all of the state.
-
-```js
-function mapStateToProps( state ) {
-  return {
-    state
-  };
-}
-
-export default App;
-```
-
-Now that we have a `mapStateToProps` function we can use it with `connect` to connect `src/App.js` to the `redux` store.
-
-```js
-function mapStateToProps( state ) {
-  return {
-    state
-  };
-}
-
-export default connect( mapStateToProps )( App );
-```
-</details>
+* In the App component, delete the constructor and state.
+* Delete all the handler methods.
+* In `render()`, delete everything but the `div` with the router.
 
 ### Solution
 
@@ -508,146 +464,7 @@ import React, { Component } from 'react';
 import './App.css';
 import router from './router';
 
-import { connect } from "react-redux";
-
-
 class App extends Component {
-  constructor(){
-    super()
-    this.state = {
-      //first view
-      loanType: 'Home Purchase',
-      propertyType: 'Single Family Home',
-      //second view
-      city: '',
-      //third view
-      propToBeUsedOn: '',
-      //fourth view
-      found: "false",
-      //fifth view
-      realEstateAgent: "false",
-      //sixth view
-      downPayment: 0,
-      cost: 0,
-      //seventh view
-      credit: '',
-      //eigth view
-      history: '',
-      //ninth view
-      addressOne: '',
-      addressTwo: '',
-      addressThree: '',
-      //tenth view
-      firstName: '',
-      lastName: '',
-      email: ''
-    }
-    //first view 
-    this.handleChangeLoanType = this.handleChangeLoanType.bind(this);
-    this.handleChangePropertyType = this.handleChangePropertyType.bind(this);
-    //second view
-    this.handleChangeCity = this.handleChangeCity.bind(this);
-    //third view
-    this.handleChangePropertyToBeUsedOn = this.handleChangePropertyToBeUsedOn.bind(this);
-    //fourth view
-    this.handleChangeFoundFalse = this.handleChangeFoundFalse.bind(this);
-    this.handleChangeFoundTrue = this.handleChangeFoundTrue.bind(this);
-    //fifth view
-    this.handleChangeRealEstateAgentTrue = this.handleChangeRealEstateAgentTrue.bind(this);
-    this.handleChangeRealEstateAgentFalse = this.handleChangeRealEstateAgentFalse.bind(this);
-    //sixth view
-    this.handleChangeUpdateDownPayment = this.handleChangeUpdateDownPayment.bind(this);
-    this.handleChangeUpdateCost = this.handleChangeUpdateCost.bind(this);
-    //seventh view
-    this.handleChangeCreditE = this.handleChangeCreditE.bind(this);
-    this.handleChangeCreditG = this.handleChangeCreditG.bind(this);
-    this.handleChangeCreditF = this.handleChangeCreditF.bind(this);
-    this.handleChangeCreditP = this.handleChangeCreditP.bind(this);
-    //eigth view
-    this.handleChangeUpdateHistory = this.handleChangeUpdateHistory.bind(this);
-    //ninth view
-    this.handleChangeAddressOne = this.handleChangeAddressOne.bind(this);
-    this.handleChangeAddressTwo = this.handleChangeAddressTwo.bind(this);
-    this.handleChangeAddressThree = this.handleChangeAddressThree.bind(this);
-    //tenth view
-    this.handleChangeFirstName = this.handleChangeFirstName.bind(this);
-    this.handleChangeLastName = this.handleChangeLastName.bind(this);
-    this.handleChangeEmail = this.handleChangeEmail.bind(this);
-  }
-    //first view
-    handleChangeLoanType(event) {
-        this.setState({loanType : event.target.value});
-    }
-    handleChangePropertyType(event) {
-        this.setState({propertyType : event.target.value});
-    }
-    //second view
-    handleChangeCity(event){
-        this.setState({city : event.target.value});
-    }
-    //third view
-    handleChangePropertyToBeUsedOn(event){
-        this.setState({propToBeUsedOn : event.target.value})
-    }
-    //fourth view
-    handleChangeFoundTrue(event){
-        this.setState({found : "true"});
-    }
-    handleChangeFoundFalse(event){
-        this.setState({found : "false"});
-    }
-    //fifth view
-    handleChangeRealEstateAgentTrue(){
-        this.setState({realEstateAgent : "true"});
-    }
-    handleChangeRealEstateAgentFalse(){
-        this.setState({realEstateAgent : "false"});
-    }
-    //sixth view
-    handleChangeUpdateDownPayment(event){
-        this.setState({downPayment : event.target.value})
-    }
-    handleChangeUpdateCost(event){
-      this.setState({cost: event.target.value});
-    }
-    //seventh view
-    handleChangeCreditE(){
-      this.setState({credit: 'Excellent'})
-    }
-    handleChangeCreditG(){
-      this.setState({credit: 'Good'})
-    }
-    handleChangeCreditF(){
-      this.setState({credit: 'Fair'})
-    }
-    handleChangeCreditP(){
-      this.setState({credit: 'Poor'})
-    }
-    //eigth view
-    handleChangeUpdateHistory(event){
-      this.setState({history: event.target.value})
-    }
-    //ninth view
-    handleChangeAddressOne(event){
-      this.setState({addressOne: event.target.value})
-    }
-    handleChangeAddressTwo(event){
-      this.setState({addressTwo: event.target.value})
-    }
-    handleChangeAddressThree(event){
-      this.setState({addressThree: event.target.value})
-    }
-    //tenth view
-    handleChangeFirstName(event){
-      this.setState({firstName : event.target.value})
-    }
-    handleChangeLastName(event){
-      this.setState({lastName: event.target.value})
-    }
-    handleChangeEmail(event){
-      this.setState({email: event.target.value})
-    }
-
   render() {
     return (
       <div>
@@ -657,11 +474,7 @@ class App extends Component {
   }
 }
 
-function mapStateToProps( state ) {
-  return state
-}
-
-export default connect( mapStateToProps )( App );
+export default App;
 ```
 
 </details>
@@ -670,7 +483,7 @@ export default connect( mapStateToProps )( App );
 
 ### Summary
 
-Now that our `src/App.js` is connected to our `redux` store, let's begin connecting our views. We'll start with the Eleventh view. I chose the Eleventh view because as we start hooking our views up with `redux`, we'll be able to see the data getting to where it needs to end up.
+Let's begin connecting our views. We'll start with the Eleventh view. I chose the Eleventh view because as we start hooking our views up with `redux`, we'll be able to see the data getting to where it needs to end up.
 
 ### Instructions 
 


### PR DESCRIPTION
I've been seeing students with bad habits, hooking up their app's `App.js` sometimes for no reason. I finally asked a student where they are getting this from, and they suggested it was the redux afternoon project. I looked and realized we are telling students to `connect()` their `App.js` to the redux store, even when they aren't getting anything from the store or dispatching anything to the store. I've removed the step in the README telling students to do that.